### PR TITLE
Refactored "package" variable name

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 
 var http = require('http')
 var methods = require('./methods')
-var package = require('../package.json')
+var pkg = require('../package.json')
 var response = require('./response')
 
 var Server = module.exports = function() {
@@ -14,7 +14,7 @@ var Server = module.exports = function() {
 
   fn.headers = {
     'Accept-Ranges': 'bytes',
-    'Server': package.name + '/' + package.version
+    'Server': pkg.name + '/' + pkg.version
   }
 
   fn.listen = function () {


### PR DESCRIPTION
Renamed the "package" variable - this is a future reserved keyword in the ECMAScript specification and should be avoided.
